### PR TITLE
Compatibility patches for animal mods

### DIFF
--- a/1.3/Patches/BirdsBeyondTemperateForest.xml
+++ b/1.3/Patches/BirdsBeyondTemperateForest.xml
@@ -1,0 +1,71 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Birds Beyond: Temperate Forest</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/BiomeDef[defName="AB_GallatrossGraveyard"]/wildAnimals</xpath>
+					<value>
+						<BB_Kestrel>0.1</BB_Kestrel>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/BiomeDef[defName="AB_GelatinousSuperorganism"]/wildAnimals</xpath>
+					<value>
+						<BB_BarnOwl>0.05</BB_BarnOwl>
+						<BB_Crow>0.1</BB_Crow>
+						<BB_EagleOwl>0.05</BB_EagleOwl>
+						<BB_Kestrel>0.05</BB_Kestrel>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/BiomeDef[defName="AB_IdyllicMeadows"]/wildAnimals</xpath>
+					<value>
+						<BB_BarnOwl>0.1</BB_BarnOwl>
+						<BB_Crow>0.3</BB_Crow>
+						<BB_EagleOwl>0.1</BB_EagleOwl>
+						<BB_Kestrel>0.05</BB_Kestrel>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/BiomeDef[defName="AB_MechanoidIntrusion"]/wildAnimals</xpath>
+					<value>
+						<BB_Crow>0.05</BB_Crow>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/BiomeDef[defName="AB_MycoticJungle"]/wildAnimals</xpath>
+					<value>
+						<BB_BarnOwl>0.1</BB_BarnOwl>
+						<BB_Crow>0.2</BB_Crow>
+						<BB_EagleOwl>0.05</BB_EagleOwl>
+						<BB_Kestrel>0.05</BB_Kestrel>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/BiomeDef[defName="AB_OcularForest"]/wildAnimals</xpath>
+					<value>
+						<BB_BarnOwl>0.2</BB_BarnOwl>
+						<BB_Crow>0.2</BB_Crow>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/BiomeDef[defName="AB_RockyCrags"]/wildAnimals</xpath>
+					<value>
+						<BB_BarnOwl>0.2</BB_BarnOwl>
+						<BB_EagleOwl>0.2</BB_EagleOwl>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/BiomeDef[defName="AB_TarPits"]/wildAnimals</xpath>
+					<value>
+						<BB_Kestrel>0.05</BB_Kestrel>
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/1.3/Patches/BirdsBeyondTropicalForest.xml
+++ b/1.3/Patches/BirdsBeyondTropicalForest.xml
@@ -1,0 +1,40 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Birds Beyond: Tropical Rainforest</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/BiomeDef[defName="AB_FeraliskInfestedJungle"]/wildAnimals</xpath>
+					<value>
+						<BB_Cockatoo>0.05</BB_Cockatoo>
+						<BB_Hornbill>0.05</BB_Hornbill>
+						<BB_Parrot>0.1</BB_Parrot>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/BiomeDef[defName="AB_MiasmicMangrove"]/wildAnimals</xpath>
+					<value>
+						<BB_Cockatoo>0.3</BB_Cockatoo>
+						<BB_Hornbill>0.15</BB_Hornbill>
+						<BB_Toucan>0.1</BB_Toucan>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/BiomeDef[defName="AB_MycoticJungle"]/wildAnimals</xpath>
+					<value>
+						<BB_Parrot>0.1</BB_Parrot>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/BiomeDef[defName="AB_OcularForest"]/wildAnimals</xpath>
+					<value>
+						<BB_Parrot>0.1</BB_Parrot>
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/1.3/Patches/ErinsAmaro.xml
+++ b/1.3/Patches/ErinsAmaro.xml
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Erin's Amaro</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/BiomeDef[defName="AB_GelatinousSuperorganism" or defName="AB_MiasmicMangrove" or
+						defName="AB_PyroclasticConflagration" or defName="AB_TarPits"]/wildAnimals
+					</xpath>
+					<value>
+						<ERN_Amaro>0.05</ERN_Amaro>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/BiomeDef[defName="AB_IdyllicMeadows" or defName="AB_MycoticJungle"]/wildAnimals</xpath>
+					<value>
+						<ERN_Amaro>0.1</ERN_Amaro>
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/1.3/Patches/ErinsCarbuncles.xml
+++ b/1.3/Patches/ErinsCarbuncles.xml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Erin's Carbuncles</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/BiomeDef[defName="AB_IdyllicMeadows" or defName="AB_MycoticJungle"]/wildAnimals</xpath>
+					<value>
+						<ERN_Carbuncle>0.02</ERN_Carbuncle>
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/1.3/Patches/ErinsFoxSquirrel.xml
+++ b/1.3/Patches/ErinsFoxSquirrel.xml
@@ -1,0 +1,31 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Erin's Fox Squirrel</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/BiomeDef[defName="AB_FeraliskInfestedJungle" or defName="AB_MycoticJungle"]/wildAnimals
+					</xpath>
+					<value>
+						<FoxSquirrel>0.05</FoxSquirrel>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/BiomeDef[defName="AB_IdyllicMeadows" or defName="AB_OcularForest"]/wildAnimals</xpath>
+					<value>
+						<FoxSquirrel>0.1</FoxSquirrel>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/BiomeDef[defName="AB_MiasmicMangrove"]/wildAnimals</xpath>
+					<value>
+						<FoxSquirrel>0.5</FoxSquirrel>
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/1.3/Patches/ErinsFriendlyFerrets.xml
+++ b/1.3/Patches/ErinsFriendlyFerrets.xml
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Erin's Friendly Ferrets</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/BiomeDef[defName="AB_IdyllicMeadows" or defName="AB_MycoticJungle"]/wildAnimals
+					</xpath>
+					<value>
+						<ERN_Ferret>0.2</ERN_Ferret>
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/1.3/Patches/OpossumFriends.xml
+++ b/1.3/Patches/OpossumFriends.xml
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Opossum Friends</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/BiomeDef[defName="AB_GelatinousSuperorganism" or defName="AB_IdyllicMeadows" or
+						defName="AB_MycoticJungle"]/wildAnimals
+					</xpath>
+					<value>
+						<ERN_Opossum>0.1</ERN_Opossum>
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/1.3/Patches/RegrowthRemasteredExtinctAnimals.xml
+++ b/1.3/Patches/RegrowthRemasteredExtinctAnimals.xml
@@ -1,0 +1,89 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>ReGrowth Remastered: Extinct Animals</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/BiomeDef[defName="AB_FeraliskInfestedJungle"]/wildAnimals
+					</xpath>
+					<value>
+						<RG_TerrorBird>0.1</RG_TerrorBird>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/BiomeDef[defName="AB_GallatrossGraveyard"]/wildAnimals
+					</xpath>
+					<value>
+						<RG_TerrorBird>0.2</RG_TerrorBird>
+						<RG_Thrinaxodon>0.1</RG_Thrinaxodon>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/BiomeDef[defName="AB_GelatinousSuperorganism"]/wildAnimals
+					</xpath>
+					<value>
+						<RG_TerrorBird>0.05</RG_TerrorBird>
+						<RG_Megalenhydris>0.1</RG_Megalenhydris>
+						<RG_Thrinaxodon>0.05</RG_Thrinaxodon>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/BiomeDef[defName="AB_IdyllicMeadows"]/wildAnimals
+					</xpath>
+					<value>
+						<RG_Protoceratidae>0.1</RG_Protoceratidae>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/BiomeDef[defName="AB_MechanoidIntrusion"]/wildAnimals
+					</xpath>
+					<value>
+						<RG_SabertoothSquirrel>0.05</RG_SabertoothSquirrel>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/BiomeDef[defName="AB_MiasmicMangrove"]/wildAnimals
+					</xpath>
+					<value>
+						<RG_TerrorBird>0.1</RG_TerrorBird>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/BiomeDef[defName="AB_MycoticJungle"]/wildAnimals
+					</xpath>
+					<value>
+						<RG_Protoceratidae>0.1</RG_Protoceratidae>
+						<RG_TerrorBird>0.05</RG_TerrorBird>
+						<RG_Megalenhydris>0.1</RG_Megalenhydris>
+						<RG_Velociraptor>0.05</RG_Velociraptor>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/BiomeDef[defName="AB_PropaneLakes"]/wildAnimals
+					</xpath>
+					<value>
+						<RG_WoollyMammoth>0.1</RG_WoollyMammoth>
+						<RG_WoollyRhinoceros>0.1</RG_WoollyRhinoceros>
+						<RG_WoollyStegosaurus>0.05</RG_WoollyStegosaurus>
+						<RG_SabertoothSquirrel>0.05</RG_SabertoothSquirrel>
+						<RG_ArcticDrak>0.05</RG_ArcticDrak>
+						<RG_ArcticLuizicus>0.1</RG_ArcticLuizicus>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/BiomeDef[defName="AB_TarPits"]/wildAnimals
+					</xpath>
+					<value>
+						<RG_Protoceratidae>0.2</RG_Protoceratidae>
+						<RG_TerrorBird>0.3</RG_TerrorBird>
+						<RG_Thrinaxodon>0.1</RG_Thrinaxodon>
+						<RG_Velociraptor>0.1</RG_Velociraptor>
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>


### PR DESCRIPTION
This PR includes compatibility patches to let animals from the following mods spawn in alpha biomes:

- Birds Beyond: Temperate Forest
- Birds Beyond: Tropical Forest
- Erin's Amaro
- Erin's Carbuncles
- Erin's Fox Squirrel
- Erin's Friendly Ferrets
- Opossum Friends
- ReGrowth Remastered: Extinct Animals